### PR TITLE
Quickfix for the sidebar links and typos

### DIFF
--- a/_includes/sidebar-conference.html
+++ b/_includes/sidebar-conference.html
@@ -7,7 +7,7 @@
       url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Organization.html"
       title="Committees"%}  <br/>
       {% include sidebar-nav-item.html
-      url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020.html" title="Local homepage" %}  <br/>
+      url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020.html" title="Local Homepage" %}  <br/>
       {% include sidebar-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Sessions.html" title="Sessions" %} <hr/> 
       {% include sidebar-edit.html %}<br/>
       {% include sidebar-nav-item.html url="/follow/"     title="Contact" %},

--- a/_includes/sidebar-upcoming.html
+++ b/_includes/sidebar-upcoming.html
@@ -3,12 +3,12 @@
     {% include sidebar-about.html %}
     <nav class="sidebar-nav">
       {% include sidebar-nav-item.html url="/"            title="ICMS Home" %} <hr/>
-      {% include sidebar-congress-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Organization.html"  title="Committees" %}  <br/>
-      {% include sidebar-congress-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020.html" title="Local Homepage" %}  <br/> 
+      {% include sidebar-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Organization.html"  title="Committees" %}  <br/>
+      {% include sidebar-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020.html" title="Local Homepage" %}  <br/> 
       <!-- {% include sidebar-congress-nav-item.html path="invited-speakers/" title="Invited Speakers" %}  <br/> -->
       <!-- {% include sidebar-congress-nav-item.html path="daily-program/"     title="Daily Program" %}  <br/> -->
       <!-- {% include sidebar-congress-nav-item.html path="overall-program/"     title="Overall Program" %}  <br/> -->
-      {% include sidebar-congress-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Sessions.html"  year=year   title="Sessions" %}  <br/>
+      {% include sidebar-nav-item.html url="http://www.iaa.tu-bs.de/AppliedAlgebra/ICMS2020/ICMS2020_Sessions.html"  year=year   title="Sessions" %}  <br/>
       <!-- {% include sidebar-congress-nav-item.html path="dates/"     title="Important Dates" %}  <br/> -->
       <!-- {% include sidebar-congress-nav-item.html path="call-for-posters/"     title="Call for Posters" %}  <br/>-->
       <!-- {% include sidebar-congress-nav-item.html path="call-for-session-proposals/"     title="Call for Session Proposals" %}  <br/> -->


### PR DESCRIPTION
After the last change, the buttons on the sidebar was okay but the links were still broken. I still do not understand why _sidebar-congress-nav-item.html_ does not function properly. However it seems like using _sidebar-nav-item.html_ instead should do the trick.