### PR TITLE
Fine tuning schedule table for Bies-Kastner-Zach session

### DIFF
--- a/2024/sessions/session_Bies_Kastner_Zach.md
+++ b/2024/sessions/session_Bies_Kastner_Zach.md
@@ -27,7 +27,7 @@ Recent years have shown new applications of symbolic methods in computer algebra
 
 All talks in this session will take place on Thursday, July 25. The schedule is as follows:
 
-| Time | Title | Speaker |
+| Time &nbsp; &nbsp; | Title | Speaker |
 | -------- | -------- | -------- |
 | 9.00 - 10.00 | Plenary Talk |
 | 10.00 - 10.30 | Coffee | |


### PR DESCRIPTION
For aesthetics, the first column of the schedule (with times) should not wrap the text. This PR attempts to make the first column wider.

(I would have loved to try it locally, but am not certain how. So the spacing may not be correct yet.)

cc @lkastner @HechtiDerLachs @YueRen 