### PR TITLE
Tell image to never be larger than its container

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -228,9 +228,9 @@ blockquote p:last-child {
 }
 
 img {
-/*  display: block;
+  /*display: block;*/
   max-width: 100%;
-  margin: 0 0 1rem;
+  /*margin: 0 0 1rem;
   border-radius: 5px;*/
 }
 


### PR DESCRIPTION
In https://icms-conference.org/2024/sessions/session_Bies_Kastner_Zach/, the session picture is a lot larger than its container. Hence, only a small section of said picture is currently being displayed (at least in my browser).

Ideally, the change in this PR should inform the website that a picture must never be larger than 100% the size of its container. In other words, I would expect that images are automatically scaled to fit into their container.

I find it hard to gauge if and to what extend this might affect other pages/older ICMS websites. Please check carefully before merging.

If you have alternative/better thoughts on how to adjust the scale of the session picture mentioned above, please do let me know.

cc @YueRen 